### PR TITLE
Made Intents optional in Client constructor

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -4159,7 +4159,7 @@ export interface ClientOptions {
   failIfNotExists?: boolean;
   userAgentSuffix?: string[];
   presence?: PresenceData;
-  intents: BitFieldResolvable<IntentsString, number>;
+  intents?: BitFieldResolvable<IntentsString, number>;
   waitGuildTimeout?: number;
   sweepers?: SweeperOptions;
   ws?: WebSocketOptions;


### PR DESCRIPTION
This allows the [custom settings](https://github.com/aiko-chan-ai/discord.js-selfbot-v13/blob/main/Document/ClientOption.md#client-settings) to be used in TS again.