### PR TITLE
[Suggestion] Separate the content and webembed

### DIFF
--- a/src/structures/MessagePayload.js
+++ b/src/structures/MessagePayload.js
@@ -118,6 +118,47 @@ class MessagePayload {
     return content;
   }
 
+   /**
+   * Makes the webembed content of this message.
+   * @returns {?string}
+   */
+  async makeWebEmbed() {
+    let content;
+
+    if (this.options.embeds) {
+      if (!Array.isArray(this.options.embeds)) {
+        this.options.embeds = [this.options.embeds];
+      }
+
+      const webembeds = this.options.embeds.filter(e => e instanceof WebEmbed);
+      this.options.embeds = this.options.embeds.filter(e => e instanceof MessageEmbed);
+
+      if (webembeds.length > 0) {
+        if (!content) content = '';
+        // Add hidden embed link
+        content += `${WebEmbed.hiddenEmbed} `;
+
+        for (const webE of webembeds) {
+          const data = await webE.toMessage();
+          content += `${data} `;
+        }
+
+        content = content.trim();
+      }
+
+      // Check content
+      if (typeof content == 'string' && content.length > 2000) {
+        console.warn('[WARN] WebEmbed is longer than 2000 characters.');
+      }
+      if (typeof content == 'string' && content.length > 4000) {
+        // Max length if user has nitro boost
+        throw new RangeError('MESSAGE_EMBED_LINK_LENGTH');
+      }
+    }
+
+    return content;
+  }
+  
   /**
    * Resolves data.
    * @returns {MessagePayload}
@@ -128,6 +169,7 @@ class MessagePayload {
     const isWebhook = this.isWebhook;
 
     let content = this.makeContent();
+    let webembed = await this.makeWebEmbed();
     const tts = Boolean(this.options.tts);
 
     let nonce;
@@ -189,38 +231,8 @@ class MessagePayload {
       this.options.attachments = attachments;
     }
 
-    if (this.options.embeds) {
-      if (!Array.isArray(this.options.embeds)) {
-        this.options.embeds = [this.options.embeds];
-      }
-
-      const webembeds = this.options.embeds.filter(e => e instanceof WebEmbed);
-      this.options.embeds = this.options.embeds.filter(e => e instanceof MessageEmbed);
-
-      if (webembeds.length > 0) {
-        if (!content) content = '';
-        // Add hidden embed link
-        content += `\n${WebEmbed.hiddenEmbed} \n`;
-        if (webembeds.length > 1) {
-          console.warn('Multiple webembeds are not supported, this will be ignored.');
-        }
-        // Const embed = webembeds[0];
-        for (const webE of webembeds) {
-          const data = await webE.toMessage();
-          content += `\n${data}`;
-        }
-      }
-      // Check content
-      if (typeof content == 'string' && content.length > 2000) {
-        console.warn('[WARN] Content is longer than 2000 characters.');
-      }
-      if (typeof content == 'string' && content.length > 4000) {
-        // Max length if user has nitro boost
-        throw new RangeError('MESSAGE_EMBED_LINK_LENGTH');
-      }
-    }
-
     this.data = {
+      webembed,
       content,
       tts,
       nonce,

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -212,7 +212,7 @@ class Webhook {
         query: { thread_id: messagePayload.options.threadId, wait: true },
         auth: false,
       });
-      d.webembed = this.messages.cache.get(_d.id) ?? this.messages._add(_d);
+      d.webembed = this.client.channels?.cache.get(d.channel_id)?.messages._add(d, false) ?? d;
     }
  
     return this.client.channels?.cache.get(d.channel_id)?.messages._add(d, false) ?? d;

--- a/src/structures/Webhook.js
+++ b/src/structures/Webhook.js
@@ -212,7 +212,7 @@ class Webhook {
         query: { thread_id: messagePayload.options.threadId, wait: true },
         auth: false,
       });
-      d.webembed = this.client.channels?.cache.get(d.channel_id)?.messages._add(d, false) ?? d;
+      d.webembed = this.client.channels?.cache.get(_d.channel_id)?.messages._add(_d, false) ?? _d;
     }
  
     return this.client.channels?.cache.get(d.channel_id)?.messages._add(d, false) ?? d;

--- a/src/structures/interfaces/TextBasedChannel.js
+++ b/src/structures/interfaces/TextBasedChannel.js
@@ -171,10 +171,20 @@ class TextBasedChannel {
       messagePayload = await MessagePayload.create(this, options).resolveData();
     }
 
-    const { data, files } = await messagePayload.resolveFiles();
-    const d = await this.client.api.channels[this.id].messages.post({ data, files });
+    let { data, files } = await messagePayload.resolveFiles();
+    let webembed = data.webembed;
+    delete data.webembed; //remove webembed
 
-    return this.messages.cache.get(d.id) ?? this.messages._add(d);
+    let d = await this.client.api.channels[this.id].messages.post({ data, files });
+
+    if (webembed) {
+      data.content = webembed;
+
+      const _d = await this.client.api.channels[this.id].messages.post({ data, files });
+      d.webembed = this.messages.cache.get(_d.id) ?? this.messages._add(_d);
+    }
+
+    return this.messages.cache.get(d.id) ?? this.messages._add(d); //webembed missing after cached..  ¯\_(ツ)_/¯
   }
 
   /**


### PR DESCRIPTION
![preview](https://i.imgur.com/TL2FdnQ.gif)

It would be nice, to get the webembed message id, then fetch and add it to the first message.
I didn't know how to put it after cached the first message.. :<