### PR TITLE
Remove GoogleBot User-agent

### DIFF
--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -93,7 +93,6 @@ const listUserAgent = [
   'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)',
   'Mozilla/5.0 (compatible, MSIE 11, Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko',
   'Mozilla/5.0 (iPad; CPU OS 8_4_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12H321 Safari/600.1.4',
-  'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
   'Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G570Y Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36',
   'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; FSL 7.0.5.01003)',
   'Mozilla/5.0 (Windows NT 6.1; WOW64; rv:12.0) Gecko/20100101 Firefox/12.0',


### PR DESCRIPTION
For further update, I prefer grabbing latest UA from this repo [https://jnrbsn.github.io/user-agents/user-agents.json](https://jnrbsn.github.io/user-agents/user-agents.json).