### PR TITLE
Add user account functionality for fetching active threads

### DIFF
--- a/src/managers/ThreadManager.js
+++ b/src/managers/ThreadManager.js
@@ -226,15 +226,29 @@ class ThreadManager extends CachedManager {
   }
 
   /**
+   * Discord.js self-bot specific options field for fetching active threads.
+   * @typedef {Object} FetchChannelThreadsOptions 
+   * @property {string} [sort_by] The order in which the threads should be fetched in (default is last_message_time)
+   * @property {string} [sort_order] How the threads should be ordered (default is desc)
+   * @property {number} [limit] The maximum number of threads to return (default is 25)
+   * @property {number} [offset] The number of threads to offset fetching (useful when making multiple fetches) (default is 0)
+  */
+
+  /**
    * Obtains the accessible active threads from Discord, requires `READ_MESSAGE_HISTORY` in the parent channel.
    * @param {boolean} [cache=true] Whether to cache the new thread objects if they aren't already
+   * @param {FetchChannelThreadsOptions} [selfbot_options] Options for self-bots where advanced users can specify further options
    * @returns {Promise<FetchedThreads>}
    */
-  async fetchActive(cache = true) {
-    if (!this.client.user.bot) {
-      throw new Error('INVALID_USER_METHOD: User accounts cannot use this method\nI will fix it .-.');
+  async fetchActive(cache = true, options = null) {
+    if (options && this.client.user.bot) {
+      throw new Error('INVALID_BOT_OPTIONS: Options can only be specified for user accounts.');
     }
-    const raw = await this.client.api.guilds(this.channel.guild.id).threads.active.get();
+
+    const raw = this.client.user.bot ? 
+      await this.client.api.guilds(this.channel.guild.id).threads.active.get()
+      : await this.client.api.channels(this.channel.id).threads[`search?archived=false&limit=${options?.limit || '25'}&offset=${options?.offset || '0'}&sort_by=${options?.sort_by || 'last_message_time'}&sort_order=${options?.sort_order || 'desc'}`].get();
+      
     return this.constructor._mapThreads(raw, this.client, { parent: this.channel, cache });
   }
 


### PR DESCRIPTION
Closes #119

This PR fixes the `Only bots can use this endpoint` issue when using `channel#fetchActive` while still keeping support for bot accounts.

But that's not all! Since user accounts support more advanced queries for fetching threads, I have added an optional field which accepts an object with the supported parameters, currently only being `limit=25`, `offset=0`, `sort_by=last_message_time`, `sort_order=desc`.

The reason I have included such specific default values is because that's the default values Discord uses for their client, and (while unlikely) they could be tracking unusual API requests which may lead to a ban (still very unlikely) - if you're not happy with this and want to tune the settings, go right ahead!

### Examples:

```js
// Do a simple fetch with default options and print all thread names to console.
const threadFetch = await channel.threads.fetchActive();
for (const thread of threadFetch.threads.values()) {
   console.log(thread.name);
}

// Fetch threads with a specific limit other than 25 (do note it's up to Discord whether it respects your value or not).
const threadFetch = await channel.threads.fetchActive(true, { limit: 10 });

// Fetch 10 threads, skipping 20 threads in the process (this is very useful for pagination if you do not want to configure a higher limit or Discord ignores your higher limit, for example in this case you could show 10 threads to the user and let them move to another page showing different threads).
const threadFetch = await channel.threads.fetchActive(true, { limit: 10, offset: 20 });
```

**To-do: document other options you can supply to the method.**