### PR TITLE
Fix slashCommand of type SUB_COMMAND_GROUP

### DIFF
--- a/src/structures/ApplicationCommand.js
+++ b/src/structures/ApplicationCommand.js
@@ -697,7 +697,7 @@ class ApplicationCommand extends Base {
                   const subGroup = this.options.find(
                     o => o.name == subCommandArray[0] && o.type == 'SUB_COMMAND_GROUP',
                   );
-                  const subCommand = this.options.find(o => o.name == subCommandArray[1] && o.type == 'SUB_COMMAND');
+                  const subCommand = subGroup.options.find(o => o.name == subCommandArray[1] && o.type == 'SUB_COMMAND');
                   optionsBuild = [
                     {
                       type: ApplicationCommandOptionTypes[subGroup.type],


### PR DESCRIPTION
I tried to run a slash command like this: `this.channel.sendSlash(BOT_ID, 'trade item for_items', '1', 'itemName', 'True');`

I ran into an exception saying "`Cannot read properties of undefined (reading 'type')`"

After debugging it, I got it working again with this small adjustment.