### PR TITLE
feat: automatic timezone detection

### DIFF
--- a/src/rest/APIRequest.js
+++ b/src/rest/APIRequest.js
@@ -80,7 +80,7 @@ class APIRequest {
       'sec-fetch-site': 'same-origin',
       'x-debug-options': 'bugReporterEnabled',
       'x-discord-locale': 'en-US',
-      'x-discord-timezone': 'Asia/Saigon',
+      'x-discord-timezone': Intl.DateTimeFormat().resolvedOptions().timeZone,
       'x-super-properties': `${Buffer.from(JSON.stringify(this.client.options.ws.properties), 'ascii').toString(
         'base64',
       )}`,


### PR DESCRIPTION
Uses [Intl](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) to automatically detect the timezone of the machine and change "x-discord-timezone" accordingly to not have it be a hard coded value