### PR TITLE
Fix: Resolve `buildConnector` Issue with Newer Unidici Versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "qrcode": "^1.5.4",
     "tough-cookie": "^4.1.4",
     "tree-kill": "^1.2.2",
-    "undici": "^6.21.0",
+    "undici": "5.28.4",
     "ws": "^8.16.0"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,8 +42,8 @@ importers:
         specifier: ^1.2.2
         version: 1.2.2
       undici:
-        specifier: ^6.21.0
-        version: 6.21.0
+        specifier: 5.28.4
+        version: 5.28.4
       ws:
         specifier: ^8.16.0
         version: 8.18.0
@@ -403,6 +403,10 @@ packages:
   '@eslint/js@8.57.0':
     resolution: {integrity: sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
 
   '@favware/npm-deprecate@1.0.7':
     resolution: {integrity: sha512-rCQdip+YfML29gzhSuXwZsJI5BwWp4uhHQZwDOR0DuzUrF+HXcmt7QWRzyUeseDqQKWnptRgmdpnrkm/qPUCbw==}
@@ -3684,9 +3688,9 @@ packages:
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
-  undici@6.21.0:
-    resolution: {integrity: sha512-BUgJXc752Kou3oOIuU1i+yZZypyZRqNPW0vqoMPl8VaoalSfeR0D8/t4iAS3yirs79SSMTxTag+ZC86uswv+Cw==}
-    engines: {node: '>=18.17'}
+  undici@5.28.4:
+    resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
+    engines: {node: '>=14.0'}
 
   unique-filename@3.0.0:
     resolution: {integrity: sha512-afXhuC55wkAmZ0P18QsVE6kp8JaxrEokN2HGIoIVv2ijHQd419H0+6EigAFcIzXeMIkcIkNBpB3L/DXB3cTS/g==}
@@ -4303,6 +4307,8 @@ snapshots:
       - supports-color
 
   '@eslint/js@8.57.0': {}
+
+  '@fastify/busboy@2.1.1': {}
 
   '@favware/npm-deprecate@1.0.7(encoding@0.1.13)':
     dependencies:
@@ -8228,7 +8234,9 @@ snapshots:
 
   undici-types@5.26.5: {}
 
-  undici@6.21.0: {}
+  undici@5.28.4:
+    dependencies:
+      '@fastify/busboy': 2.1.1
 
   unique-filename@3.0.0:
     dependencies:


### PR DESCRIPTION
When trying to make API requests such as using `Channel.delete()` , the code threw this error:  

```
buildConnector is not a function. (In 'buildConnector({ ciphers: ciphers.join(":") })', 'buildConnector' is undefined)
    at new HTTPError (node_modules/discord.js-selfbot-v13/src/rest/HTTPError.js:9:5)
    at <anonymous> (node_modules/discord.js-selfbot-v13/src/rest/RequestHandler.js:213:19)
    at execute (node_modules/discord.js-selfbot-v13/src/rest/RequestHandler.js:118:17)
    at execute (node_modules/discord.js-selfbot-v13/src/rest/RequestHandler.js:118:17)
    at <anonymous> (node_modules/discord.js-selfbot-v13/src/rest/RequestHandler.js:63:25)
    at processTicksAndRejections (native:7:39)
```

This happened because Unidici no longer supports `buildConnector` in versions 6.x.x and above.  I downgraded Unidici to a version where `buildConnector` is still available (below 5.28.4).