### PR TITLE
Fix TOTP Generation and Request Handler Access Path

### DIFF
--- a/src/rest/RequestHandler.js
+++ b/src/rest/RequestHandler.js
@@ -396,7 +396,7 @@ class RequestHandler {
           request.retries < 1
         ) {
           // Get mfa code
-          const { otp } = await TOTP.generate(this.options.TOTPKey);
+          const { otp } = await TOTP.generate(this.manager.client.options.TOTPKey);
           this.manager.client.emit(
             DEBUG,
             `${data.message}

--- a/src/util/Totp.js
+++ b/src/util/Totp.js
@@ -30,7 +30,7 @@ class TOTP {
       timestamp: Date.now(),
       ...options,
     };
-    const epochSeconds = Math.floor(_options.timestam / 1000);
+    const epochSeconds = Math.floor(_options.timestamp / 1000);
     const timeHex = this.dec2hex(Math.floor(epochSeconds / _options.period)).padStart(16, '0');
 
     const keyBuffer = _options.encoding === 'hex' ? this.base32ToBuffer(key) : this.asciiToBuffer(key);


### PR DESCRIPTION
This PR addresses two key issues in the TOTP implementation and request handling:

1. **Fixed Timestamp Typo in TOTP Generation**
   - Corrected the typo in `_options.timestam` to `_options.timestamp`
   - This fix ensures accurate time-based token generation by properly calculating epoch seconds

2. **Updated TOTP Key Access Path in Request Handler**
   - Changed the TOTP key access from `this.options.TOTPKey` to `this.manager.client.options.TOTPKey`
   - This ensures the correct access path to the TOTP key through the client instance

These changes resolve issues with:
- Incorrect TOTP token generation due to timestamp calculation errors
- Failed two-factor authentication due to invalid key access path

Testing:
- Verified TOTP token generation works correctly with the fixed timestamp
- Confirmed successful 2FA operations using the updated key access path
- Tested compatibility with external authenticator apps