### PR TITLE
fix(SessionManager): SessionManager.fetch() returning an empty SessionManager

### DIFF
--- a/src/managers/SessionManager.js
+++ b/src/managers/SessionManager.js
@@ -19,22 +19,21 @@ class SessionManager extends CachedManager {
 
   /**
    * Fetch all sessions of the client.
-   * @returns {Promise<SessionManager>}
+   * @returns {Promise<Collection<string, Session>>}
    */
   fetch() {
-    return new Promise((resolve, reject) => {
-      this.client.api.auth.sessions
-        .get()
-        .then(data => {
-          const allData = data.user_sessions;
-          this.cache.clear();
-          for (const session of allData) {
-            this._add(new Session(this.client, session), true, { id: session.id_hash });
-          }
-          resolve(this);
-        })
-        .catch(reject);
-    });
+    return this.client.api.auth.sessions
+      .get()
+      .then(data => {
+        const allData = data.user_sessions;
+      
+        this.cache.clear();
+        for (const session of allData) {
+          this._add(session, true, { id: session.id_hash });
+        }
+
+        return this.cache;
+      });
   }
 
   /**


### PR DESCRIPTION
Instead of returning the SessionManager that is always empty and I couldn't figure out why, I made it return from the cache.