### PR TITLE
Changed GuildMemberManager.search to use new endpoint

### DIFF
--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -253,10 +253,18 @@ class GuildMemberManager extends CachedManager {
    */
 
   /**
+   * Range bounds for a range query.
+   * @template T
+   * @typedef {Object} GuildSearchRangeBounds
+   * @property {T} [gte] The lower bound (inclusive)
+   * @property {T} [lte] The upper bound (inclusive)
+   */
+
+  /**
    * Represents a numeric or string range query.
    * @template T
    * @typedef {Object} GuildSearchRangeQuery
-   * @property {{ gte?: T, lte?: T }} range The range bounds.
+   * @property {GuildSearchRangeBounds<T>} range The range bounds
    */
 
   /**

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -9,7 +9,7 @@ const { Error, TypeError, RangeError } = require('../errors');
 const BaseGuildVoiceChannel = require('../structures/BaseGuildVoiceChannel');
 const { GuildMember } = require('../structures/GuildMember');
 const { Role } = require('../structures/Role');
-const { Events, Opcodes, GuildMemberJoinSourceTypes } = require('../util/Constants');
+const { Events, Opcodes } = require('../util/Constants');
 const { PartialTypes } = require('../util/Constants');
 const DataResolver = require('../util/DataResolver');
 const GuildMemberFlags = require('../util/GuildMemberFlags');
@@ -239,7 +239,7 @@ class GuildMemberManager extends CachedManager {
    * @property {GuildSearchUserQuery|string} [users] Filters by users using OR logic only, or a single user string.
    * @property {GuildSearchJoinSourceTypeQuery|GuildMemberJoinSourceTypes|string} [joinSourceType] Filters by invite codes using OR logic only, or a single invite code.
    * @property {GuildSearchSafetySignalsQuery} [safetySignals] Internal safety filters.
- */
+   */
 
   /**
    * A block of filters for AND/OR logic.

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -227,30 +227,30 @@ class GuildMemberManager extends CachedManager {
   }
 
   /**
- * Options for searching guild members using logical filter queries.
- * @typedef {Object} GuildSearchMembersOptions
- * @property {GuildSearchQueryBlock} [or] Applies a logical OR to any nested filters.
- * @property {GuildSearchQueryBlock} [and] Applies a logical AND to any nested filters.
- * @property {number} [limit=1] The maximum number of members to return.
- * @property {boolean} [cache=true] Whether to cache the results.
- * @property {GuildSearchUsernamesQuery|string} [usernames] Filters by usernames using OR logic only, or a single username string.
- * @property {GuildSearchListQuery|string} [roles] Filters by roles using OR or AND logic, or a single role.
- * @property {GuildSearchRangeQueryNumber} [guildJoinedAt] Filters by guild join timestamp using range queries only.
- * @property {GuildSearchUserQuery|string} [users] Filters by users using OR logic only, or a single user string.
- * @property {GuildSearchJoinSourceTypeQuery|string} [joinSourceType] Filters by invite codes using OR logic only, or a single invite code.
- * @property {GuildSearchSafetySignalsQuery} [safetySignals] Internal safety filters.
+   * Options for searching guild members using logical filter queries.
+   * @typedef {Object} GuildSearchMembersOptions
+   * @property {GuildSearchQueryBlock} [or] Applies a logical OR to any nested filters.
+   * @property {GuildSearchQueryBlock} [and] Applies a logical AND to any nested filters.
+   * @property {number} [limit=1] The maximum number of members to return.
+   * @property {boolean} [cache=true] Whether to cache the results.
+   * @property {GuildSearchUsernamesQuery|string} [usernames] Filters by usernames using OR logic only, or a single username string.
+   * @property {GuildSearchListQuery|string} [roles] Filters by roles using OR or AND logic, or a single role.
+   * @property {GuildSearchRangeQueryNumber} [guildJoinedAt] Filters by guild join timestamp using range queries only.
+   * @property {GuildSearchUserQuery|string} [users] Filters by users using OR logic only, or a single user string.
+   * @property {GuildSearchJoinSourceTypeQuery|GuildMemberJoinSourceTypes|string} [joinSourceType] Filters by invite codes using OR logic only, or a single invite code.
+   * @property {GuildSearchSafetySignalsQuery} [safetySignals] Internal safety filters.
  */
 
-/**
- * A block of filters for AND/OR logic.
- * @typedef {Object} GuildSearchQueryBlock
- * @property {GuildSearchUsernamesQuery} [usernames] Filters by usernames using OR logic only.
- * @property {GuildSearchListQuery} [roles] Filters by roles using OR or AND logic.
- * @property {GuildSearchRangeQueryNumber} [guildJoinedAt] Filters by guild join timestamp using range queries only.
- * @property {GuildSearchUserQuery} [users] Filters by users using OR logic only.
- * @property {GuildSearchJoinSourceTypeQuery|GuildMemberJoinSourceTypes} [joinSourceType] Filters by invite codes using OR logic only.
- * @property {GuildSearchSafetySignalsQuery} [safetySignals] Internal safety filters with restrictions on certain fields.
- */
+  /**
+   * A block of filters for AND/OR logic.
+   * @typedef {Object} GuildSearchQueryBlock
+   * @property {GuildSearchUsernamesQuery} [usernames] Filters by usernames using OR logic only.
+   * @property {GuildSearchListQuery} [roles] Filters by roles using OR or AND logic.
+   * @property {GuildSearchRangeQueryNumber} [guildJoinedAt] Filters by guild join timestamp using range queries only.
+   * @property {GuildSearchUserQuery} [users] Filters by users using OR logic only.
+   * @property {GuildSearchJoinSourceTypeQuery|GuildMemberJoinSourceTypes} [joinSourceType] Filters by invite codes using OR logic only.
+   * @property {GuildSearchSafetySignalsQuery} [safetySignals] Internal safety filters with restrictions on certain fields.
+   */
 
   /**
    * Represents an OR or AND query with string values.

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -237,7 +237,7 @@ class GuildMemberManager extends CachedManager {
    * @property {GuildSearchListQuery|string} [roles] Filters by roles using OR or AND logic, or a single role.
    * @property {GuildSearchRangeQueryNumber} [guildJoinedAt] Filters by guild join timestamp using range queries only.
    * @property {GuildSearchUserQuery|string} [users] Filters by users using OR logic only, or a single user string.
-   * @property {GuildSearchJoinSourceTypeQuery|GuildMemberJoinSourceTypes|string} [joinSourceType] Filters by invite codes using OR logic only, or a single invite code.
+   * @property {GuildSearchJoinSourceTypeQuery|number|string} [joinSourceType] Filters by invite codes using OR logic only, or a single invite code.
    * @property {GuildSearchSafetySignalsQuery} [safetySignals] Internal safety filters.
    */
 
@@ -248,7 +248,7 @@ class GuildMemberManager extends CachedManager {
    * @property {GuildSearchListQuery} [roles] Filters by roles using OR or AND logic.
    * @property {GuildSearchRangeQueryNumber} [guildJoinedAt] Filters by guild join timestamp using range queries only.
    * @property {GuildSearchUserQuery} [users] Filters by users using OR logic only.
-   * @property {GuildSearchJoinSourceTypeQuery|GuildMemberJoinSourceTypes} [joinSourceType] Filters by invite codes using OR logic only.
+   * @property {GuildSearchJoinSourceTypeQuery|number} [joinSourceType] Filters by invite codes using OR logic only.
    * @property {GuildSearchSafetySignalsQuery} [safetySignals] Internal safety filters with restrictions on certain fields.
    */
 
@@ -274,7 +274,7 @@ class GuildMemberManager extends CachedManager {
   /**
    * Represents an OR-only query for join source types.
    * @typedef {Object} GuildSearchJoinSourceTypeQuery
-   * @property {(GuildMemberJoinSourceTypes|string)[]} or Matches if any join source types.
+   * @property {(number|string)[]} or Matches if any join source types.
    */
 
   /**

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -310,7 +310,7 @@ class GuildMemberManager extends CachedManager {
    * @private
    */
   makeGuildMemberSearchBody(options) {
-    const { limit = 1, cache, or, and, ...topLevelFilters } = options;
+    const { limit = 1, or, and, ...topLevelFilters } = options;
 
     const toSnakeCase = str => str.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
 
@@ -499,8 +499,8 @@ class GuildMemberManager extends CachedManager {
    * @returns {Promise<Collection<Snowflake, GuildMember>>}
    */
   async search(options = {}) {
-    const { cache = true } = options;
-    const requestBody = this.makeGuildMemberSearchBody(options);
+    const { cache = true, ...restOptions } = options;
+    const requestBody = this.makeGuildMemberSearchBody(restOptions);
 
     const data = await this.client.api.guilds(this.guild.id, 'members-search').post({
       data: requestBody,

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -237,7 +237,7 @@ class GuildMemberManager extends CachedManager {
    * @property {GuildSearchListQuery|RoleResolvable} [roles] Filters by roles using OR or AND logic, or a single role.
    * @property {GuildSearchRangeQuery<number>} [guildJoinedAt] Filters by guild join timestamp using range queries only.
    * @property {GuildSearchUserQuery|string} [users] Filters by users using OR logic only, or a single user string.
-   * @property {GuildSearchSourceInviteCodeQuery|string} [sourceInviteCode] Filters by invite codes using OR logic only, or a single invite code.
+   * @property {GuildSearchMembersOptionsJoinSourceTypeQuery|string} [joinSourceType] Filters by invite codes using OR logic only, or a single invite code.
    * @property {GuildSearchSafetySignalsQuery} [safetySignals] Internal safety filters.
    */
 
@@ -248,7 +248,7 @@ class GuildMemberManager extends CachedManager {
    * @property {GuildSearchListQuery} [roles] Filters by roles using OR or AND logic.
    * @property {GuildSearchRangeQuery<number>} [guildJoinedAt] Filters by guild join timestamp using range queries only.
    * @property {GuildSearchUserQuery} [users] Filters by users using OR logic only.
-   * @property {GuildSearchSourceInviteCodeQuery} [sourceInviteCode] Filters by invite codes using OR logic only.
+   * @property {GuildSearchJoinSourceTypeQuery} [joinSourceType] Filters by invite codes using OR logic only.
    * @property {GuildSearchSafetySignalsQuery} [safetySignals] Internal safety filters with restrictions on certain fields.
    */
 
@@ -272,9 +272,9 @@ class GuildMemberManager extends CachedManager {
    */
 
   /**
-   * Represents an OR-only query for source invite codes.
-   * @typedef {Object} GuildSearchSourceInviteCodeQuery
-   * @property {string[]} or Matches if any invite codes match.
+   * Represents an OR-only query for join source types.
+   * @typedef {Object} GuildSearchJoinSourceTypeQuery
+   * @property {string[]} or Matches if any join source types.
    */
 
   /**
@@ -340,14 +340,14 @@ class GuildMemberManager extends CachedManager {
         }
       }
 
-      if (key === 'sourceInviteCode' && value) {
+      if (key === 'joinSourceType' && value) {
         if (value.or) {
           return { or_query: value.or };
         }
         if (value.and) {
-          throw new TypeError("'and' is not allowed for 'sourceInviteCode'. Use 'or' instead.");
+          throw new TypeError("'and' is not allowed for 'joinSourceType'. Use 'or' instead.");
         }
-        if (typeof value === 'string') {
+        if (typeof value === 'string' || typeof value === 'number') {
           return { or_query: [value] };
         }
       }
@@ -488,7 +488,7 @@ class GuildMemberManager extends CachedManager {
    * - usernames: Only supports 'or' queries
    * - users: Only supports 'or' queries and single string values
    * - guildJoinedAt: Only supports range queries
-   * - sourceInviteCode: Only supports 'or' queries
+   * - joinSourceType: Only supports 'or' queries
    * - safetySignals.unusualDmActivityUntil: Only supports 'or' queries
    * - safetySignals.communicationDisabledUntil: Only supports 'or' queries
    * - safetySignals.unusualAccountActivity: Only supports 'or' queries

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -274,14 +274,17 @@ class GuildMemberManager extends CachedManager {
    * @returns {Promise<Collection<Snowflake, GuildMember>>}
    */
   async search({ limit = 1, cache = true, ...queries } = {}) {
-    const data = await this.client.api.guilds(this.guild.id, "members-search").post({
+    const data = await this.client.api.guilds(this.guild.id, 'members-search').post({
       data: {
         limit,
-        ...queries
-      }
+        ...queries,
+      },
     });
 
-    return data.members.reduce((col, { member }) => col.set(member.user.id, this._add(member, cache)), new Collection());
+    return data.members.reduce(
+      (col, { member }) => col.set(member.user.id, this._add(member, cache)),
+      new Collection()
+    );
   }
 
   /**

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -283,7 +283,7 @@ class GuildMemberManager extends CachedManager {
 
     return data.members.reduce(
       (col, { member }) => col.set(member.user.id, this._add(member, cache)),
-      new Collection()
+      new Collection(),
     );
   }
 

--- a/src/managers/GuildMemberManager.js
+++ b/src/managers/GuildMemberManager.js
@@ -237,7 +237,7 @@ class GuildMemberManager extends CachedManager {
    * @property {GuildSearchListQuery|string} [roles] Filters by roles using OR or AND logic, or a single role.
    * @property {GuildSearchRangeQueryNumber} [guildJoinedAt] Filters by guild join timestamp using range queries only.
    * @property {GuildSearchUserQuery|string} [users] Filters by users using OR logic only, or a single user string.
-   * @property {GuildSearchJoinSourceTypeQuery|number|string} [joinSourceType] Filters by invite codes using OR logic only, or a single invite code.
+   * @property {GuildSearchJoinSourceTypeQuery|GuildMemberJoinSourceTypes|string} [joinSourceType] Filters by invite codes using OR logic only, or a single invite code.
    * @property {GuildSearchSafetySignalsQuery} [safetySignals] Internal safety filters.
    */
 
@@ -248,7 +248,7 @@ class GuildMemberManager extends CachedManager {
    * @property {GuildSearchListQuery} [roles] Filters by roles using OR or AND logic.
    * @property {GuildSearchRangeQueryNumber} [guildJoinedAt] Filters by guild join timestamp using range queries only.
    * @property {GuildSearchUserQuery} [users] Filters by users using OR logic only.
-   * @property {GuildSearchJoinSourceTypeQuery|number} [joinSourceType] Filters by invite codes using OR logic only.
+   * @property {GuildSearchJoinSourceTypeQuery|GuildMemberJoinSourceTypes} [joinSourceType] Filters by invite codes using OR logic only.
    * @property {GuildSearchSafetySignalsQuery} [safetySignals] Internal safety filters with restrictions on certain fields.
    */
 
@@ -274,7 +274,7 @@ class GuildMemberManager extends CachedManager {
   /**
    * Represents an OR-only query for join source types.
    * @typedef {Object} GuildSearchJoinSourceTypeQuery
-   * @property {(number|string)[]} or Matches if any join source types.
+   * @property {Array<GuildMemberJoinSourceTypes|string>} or Matches if any join source types.
    */
 
   /**

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -1806,6 +1806,20 @@ exports.RelationshipTypes = createEnum([
 
 exports.SeparatorSpacingSizes = createEnum([null, 'SMALL', 'LARGE']);
 
+/**
+ * The types of sources from which a guild member can join.
+ * @readonly
+ * @enum {number}
+ */
+exports.GuildMemberJoinSourceTypes = {
+  BOT_INVITE: 1,
+  DISCOVERY: 3,
+  STUDENT_HUB: 4,
+  VANITY: 6,
+  MANUAL_VERIFICATION: 7,
+  LINKED_CHANNEL: 8,
+};
+
 exports._cleanupSymbol = Symbol('djsCleanup');
 
 function keyMirror(arr) {

--- a/typings/enums.d.ts
+++ b/typings/enums.d.ts
@@ -368,3 +368,12 @@ export const enum ApplicationType {
    */
   CREATOR_MONETIZATION = 4,
 }
+
+export const enum GuildMemberJoinSourceTypes {
+  BOT_INVITE = 1,
+  DISCOVERY = 3,
+  STUDENT_HUB = 4,
+  VANITY = 6,
+  MANUAL_VERIFICATION = 7,
+  LINKED_CHANNEL = 8
+}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6973,16 +6973,16 @@ interface GuildSearchMembersOptionsSafetySignalsQuery {
 
 interface GuildSearchMembersOptionsFilterFields {
   usernames?: GuildSearchMembersOptionsUsernamesQuery | string;
-  roles?: GuildSearchMembersOptionsRoleQuery | RoleResolvable;
+  roles?: GuildSearchMembersOptionsRoleQuery | string;
   guildJoinedAt?: GuildSearchMembersOptionsRangeQuery<number | Date>;
   users?: GuildSearchMembersOptionsUserQuery | string;
-  joinSourceType?: GuildSearchMembersOptionsJoinSourceTypeQuery | (number | string);
+  joinSourceType?: GuildSearchMembersOptionsJoinSourceTypeQuery | GuildMemberJoinSourceTypes | string;
   safetySignals?: GuildSearchMembersOptionsSafetySignalsQuery;
 }
 
 interface GuildSearchMembersOptionsRoleQuery {
-  or?: RoleResolvable[];
-  and?: RoleResolvable[];
+  or?: string[];
+  and?: string[];
 }
 
 export interface GuildSearchMembersOptions extends Partial<GuildSearchMembersOptionsFilterFields> {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1683,16 +1683,16 @@ export class GuildAuditLogs<T extends GuildAuditLogsResolvable = 'ALL'> {
 export class GuildAuditLogsEntry<
   TActionRaw extends GuildAuditLogsResolvable = 'ALL',
   TAction = TActionRaw extends keyof GuildAuditLogsIds
-    ? GuildAuditLogsIds[TActionRaw]
-    : TActionRaw extends null
-    ? 'ALL'
-    : TActionRaw,
+  ? GuildAuditLogsIds[TActionRaw]
+  : TActionRaw extends null
+  ? 'ALL'
+  : TActionRaw,
   TActionType extends GuildAuditLogsActionType = TAction extends keyof GuildAuditLogsTypes
-    ? GuildAuditLogsTypes[TAction][1]
-    : 'ALL',
+  ? GuildAuditLogsTypes[TAction][1]
+  : 'ALL',
   TTargetType extends GuildAuditLogsTarget = TAction extends keyof GuildAuditLogsTypes
-    ? GuildAuditLogsTypes[TAction][0]
-    : 'UNKNOWN',
+  ? GuildAuditLogsTypes[TAction][0]
+  : 'UNKNOWN',
 > {
   private constructor(guild: Guild, data: RawGuildAuditLogEntryData, logs?: GuildAuditLogs);
   public action: TAction;
@@ -2326,8 +2326,8 @@ export class MessageActionRow<
   T extends MessageActionRowComponent | ModalActionRowComponent = MessageActionRowComponent,
   U = T extends ModalActionRowComponent ? ModalActionRowComponentResolvable : MessageActionRowComponentResolvable,
   V = T extends ModalActionRowComponent
-    ? APIActionRowComponent<APIModalActionRowComponent>
-    : APIActionRowComponent<APIMessageActionRowComponent>,
+  ? APIActionRowComponent<APIModalActionRowComponent>
+  : APIActionRowComponent<APIMessageActionRowComponent>,
 > extends BaseMessageComponent {
   // tslint:disable-next-line:ban-ts-ignore
   // @ts-ignore (TS:2344, Caused by TypeScript 4.8)
@@ -4366,13 +4366,13 @@ export class ApplicationCommandPermissionsManager<
   public remove(
     options:
       | (FetchSingleOptions & {
-          users: UserResolvable | UserResolvable[];
-          roles?: RoleResolvable | RoleResolvable[];
-        })
+        users: UserResolvable | UserResolvable[];
+        roles?: RoleResolvable | RoleResolvable[];
+      })
       | (FetchSingleOptions & {
-          users?: UserResolvable | UserResolvable[];
-          roles: RoleResolvable | RoleResolvable[];
-        }),
+        users?: UserResolvable | UserResolvable[];
+        roles: RoleResolvable | RoleResolvable[];
+      }),
   ): Promise<ApplicationCommandPermissions[]>;
   public set(
     options: FetchSingleOptions & { permissions: ApplicationCommandPermissionData[] },
@@ -5333,12 +5333,12 @@ export interface ApplicationCommandChannelOption extends BaseApplicationCommandO
 
 export interface ApplicationCommandAutocompleteOption extends Omit<BaseApplicationCommandOptionsData, 'autocomplete'> {
   type:
-    | 'STRING'
-    | 'NUMBER'
-    | 'INTEGER'
-    | ApplicationCommandOptionTypes.STRING
-    | ApplicationCommandOptionTypes.NUMBER
-    | ApplicationCommandOptionTypes.INTEGER;
+  | 'STRING'
+  | 'NUMBER'
+  | 'INTEGER'
+  | ApplicationCommandOptionTypes.STRING
+  | ApplicationCommandOptionTypes.NUMBER
+  | ApplicationCommandOptionTypes.INTEGER;
   autocomplete: true;
 }
 
@@ -5728,8 +5728,8 @@ export type CacheFactory = (
 
 export type CacheWithLimitsOptions = {
   [K in keyof Caches]?: Caches[K][0]['prototype'] extends DataManager<infer K, infer V, any>
-    ? LimitedCollectionOptions<K, V> | number
-    : never;
+  ? LimitedCollectionOptions<K, V> | number
+  : never;
 };
 export interface CategoryCreateChannelOptions {
   permissionOverwrites?: OverwriteResolvable[] | Collection<Snowflake, OverwriteResolvable>;
@@ -6098,12 +6098,12 @@ export interface ConstantsClientApplicationAssetTypes {
 export type AutocompleteFocusedOption = Pick<CommandInteractionOption, 'name'> & {
   focused: true;
   type:
-    | 'STRING'
-    | 'INTEGER'
-    | 'NUMBER'
-    | ApplicationCommandOptionTypes.STRING
-    | ApplicationCommandOptionTypes.INTEGER
-    | ApplicationCommandOptionTypes.NUMBER;
+  | 'STRING'
+  | 'INTEGER'
+  | 'NUMBER'
+  | ApplicationCommandOptionTypes.STRING
+  | ApplicationCommandOptionTypes.INTEGER
+  | ApplicationCommandOptionTypes.NUMBER;
   value: string;
 };
 
@@ -6685,20 +6685,20 @@ export interface GuildAuditLogsEntryExtraField {
   MESSAGE_UNPIN: { channel: GuildTextBasedChannel | { id: Snowflake }; messageId: Snowflake };
   MEMBER_DISCONNECT: { count: number };
   CHANNEL_OVERWRITE_CREATE:
-    | Role
-    | GuildMember
-    | { id: Snowflake; name: string; type: OverwriteTypes.role }
-    | { id: Snowflake; type: OverwriteTypes.member };
+  | Role
+  | GuildMember
+  | { id: Snowflake; name: string; type: OverwriteTypes.role }
+  | { id: Snowflake; type: OverwriteTypes.member };
   CHANNEL_OVERWRITE_UPDATE:
-    | Role
-    | GuildMember
-    | { id: Snowflake; name: string; type: OverwriteTypes.role }
-    | { id: Snowflake; type: OverwriteTypes.member };
+  | Role
+  | GuildMember
+  | { id: Snowflake; name: string; type: OverwriteTypes.role }
+  | { id: Snowflake; type: OverwriteTypes.member };
   CHANNEL_OVERWRITE_DELETE:
-    | Role
-    | GuildMember
-    | { id: Snowflake; name: string; type: OverwriteTypes.role }
-    | { id: Snowflake; type: OverwriteTypes.member };
+  | Role
+  | GuildMember
+  | { id: Snowflake; name: string; type: OverwriteTypes.role }
+  | { id: Snowflake; type: OverwriteTypes.member };
   STAGE_INSTANCE_CREATE: StageChannel | { id: Snowflake };
   STAGE_INSTANCE_DELETE: StageChannel | { id: Snowflake };
   STAGE_INSTANCE_UPDATE: StageChannel | { id: Snowflake };
@@ -6928,16 +6928,28 @@ export interface GuildSearchMembersOptionsRangeQuery<
 }
 
 export interface GuildSearchMembersOptionsOrQuery {
-  or_query: string[];
+  or: string[];
 }
 
 export interface GuildSearchMembersOptionsAndQuery {
-  and_query: string[];
+  and: string[];
 }
 
 export type GuildSearchMembersOptionsListQuery =
   | GuildSearchMembersOptionsOrQuery
   | GuildSearchMembersOptionsAndQuery;
+
+export interface GuildSearchMembersOptionsUsernamesQuery {
+  or: string[];
+}
+
+export interface GuildSearchMembersOptionsUserQuery {
+  or: string[];
+}
+
+export interface GuildSearchMembersOptionsSourceInviteCodeQuery {
+  or: (GuildInviteSourceCode | string)[];
+}
 
 export type GuildSearchMembersOptionsRangeable<
   T extends GuildSearchMembersOptionsRangeValue = number,
@@ -6947,26 +6959,36 @@ export type GuildSearchMembersOptionsFlexibleQuery<
   T extends GuildSearchMembersOptionsRangeValue = number,
 > = GuildSearchMembersOptionsListQuery | GuildSearchMembersOptionsRangeable<T>;
 
+export interface GuildSearchMembersOptionsSafetySignalsOrOnlyQuery {
+  or: (number | Date | boolean)[];
+}
+
 export interface GuildSearchMembersOptionsSafetySignalsQuery {
-  unusual_dm_activity_until?: GuildSearchMembersOptionsRangeQuery<number>;
-  communication_disabled_until?: GuildSearchMembersOptionsRangeQuery<number>;
-  unusual_account_activity?: boolean;
-  automod_quarantined_username?: boolean;
+  unusualDmActivityUntil?: GuildSearchMembersOptionsRangeQuery<number | Date> | GuildSearchMembersOptionsSafetySignalsOrOnlyQuery;
+  communicationDisabledUntil?: GuildSearchMembersOptionsRangeQuery<number | Date> | GuildSearchMembersOptionsSafetySignalsOrOnlyQuery;
+  unusualAccountActivity?: boolean | GuildSearchMembersOptionsSafetySignalsOrOnlyQuery;
+  automodQuarantinedUsername?: boolean | GuildSearchMembersOptionsSafetySignalsOrOnlyQuery;
 }
 
 export interface GuildSearchMembersOptionsFilterFields {
-  usernames?: GuildSearchMembersOptionsListQuery;
-  role_ids?: GuildSearchMembersOptionsListQuery;
-  guild_joined_at?: GuildSearchMembersOptionsRangeQuery<number>;
-  user_id?: GuildSearchMembersOptionsRangeQuery<string>;
-  source_invite_code?: GuildSearchMembersOptionsListQuery;
-  safety_signals?: GuildSearchMembersOptionsSafetySignalsQuery;
+  usernames?: GuildSearchMembersOptionsUsernamesQuery | string;
+  roles?: GuildSearchMembersOptionsRoleQuery | RoleResolvable;
+  guildJoinedAt?: GuildSearchMembersOptionsRangeQuery<number | Date>;
+  users?: GuildSearchMembersOptionsUserQuery | string;
+  sourceInviteCode?: GuildSearchMembersOptionsSourceInviteCodeQuery | (number | string);
+  safetySignals?: GuildSearchMembersOptionsSafetySignalsQuery;
 }
 
-export interface GuildSearchMembersOptions {
-  or_query?: GuildSearchMembersOptionsFilterFields;
-  and_query?: GuildSearchMembersOptionsFilterFields;
+export interface GuildSearchMembersOptionsRoleQuery {
+  or?: RoleResolvable[];
+  and?: RoleResolvable[];
+}
+
+export interface GuildSearchMembersOptions extends Partial<GuildSearchMembersOptionsFilterFields> {
+  or?: GuildSearchMembersOptionsFilterFields;
+  and?: GuildSearchMembersOptionsFilterFields;
   limit?: number;
+  cache?: boolean;
 }
 
 // TODO: use conditional types for better TS support
@@ -6986,24 +7008,24 @@ export interface GuildScheduledEventCreateOptions {
 
 export type GuildScheduledEventRecurrenceRuleOptions =
   | BaseGuildScheduledEventRecurrenceRuleOptions<
-      GuildScheduledEventRecurrenceRuleFrequency.Yearly,
-      {
-        byMonth: readonly GuildScheduledEventRecurrenceRuleMonth[];
-        byMonthDay: readonly number[];
-      }
-    >
+    GuildScheduledEventRecurrenceRuleFrequency.Yearly,
+    {
+      byMonth: readonly GuildScheduledEventRecurrenceRuleMonth[];
+      byMonthDay: readonly number[];
+    }
+  >
   | BaseGuildScheduledEventRecurrenceRuleOptions<
-      GuildScheduledEventRecurrenceRuleFrequency.Monthly,
-      {
-        byNWeekday: readonly GuildScheduledEventRecurrenceRuleNWeekday[];
-      }
-    >
+    GuildScheduledEventRecurrenceRuleFrequency.Monthly,
+    {
+      byNWeekday: readonly GuildScheduledEventRecurrenceRuleNWeekday[];
+    }
+  >
   | BaseGuildScheduledEventRecurrenceRuleOptions<
-      GuildScheduledEventRecurrenceRuleFrequency.Weekly | GuildScheduledEventRecurrenceRuleFrequency.Daily,
-      {
-        byWeekday: readonly GuildScheduledEventRecurrenceRuleWeekday[];
-      }
-    >;
+    GuildScheduledEventRecurrenceRuleFrequency.Weekly | GuildScheduledEventRecurrenceRuleFrequency.Daily,
+    {
+      byWeekday: readonly GuildScheduledEventRecurrenceRuleWeekday[];
+    }
+  >;
 
 type BaseGuildScheduledEventRecurrenceRuleOptions<
   Frequency extends GuildScheduledEventRecurrenceRuleFrequency,
@@ -7041,8 +7063,8 @@ export type GuildScheduledEventManagerFetchResult<
 
 export type GuildScheduledEventManagerFetchSubscribersResult<T extends FetchGuildScheduledEventSubscribersOptions> =
   T extends { withMember: true }
-    ? Collection<Snowflake, GuildScheduledEventUser<true>>
-    : Collection<Snowflake, GuildScheduledEventUser<false>>;
+  ? Collection<Snowflake, GuildScheduledEventUser<true>>
+  : Collection<Snowflake, GuildScheduledEventUser<false>>;
 
 export type GuildScheduledEventPrivacyLevel = keyof typeof GuildScheduledEventPrivacyLevels;
 
@@ -7240,8 +7262,8 @@ export type ModalActionRowComponentResolvable =
 
 export interface MessageActionRowOptions<
   T extends
-    | MessageActionRowComponentResolvable
-    | ModalActionRowComponentResolvable = MessageActionRowComponentResolvable,
+  | MessageActionRowComponentResolvable
+  | ModalActionRowComponentResolvable = MessageActionRowComponentResolvable,
 > extends BaseMessageComponentOptions {
   components: T[];
 }
@@ -7533,8 +7555,8 @@ export type MFALevel = keyof typeof MFALevels;
 
 export interface ModalOptions {
   components:
-    | MessageActionRow<ModalActionRowComponent>[]
-    | MessageActionRowOptions<ModalActionRowComponentResolvable>[];
+  | MessageActionRow<ModalActionRowComponent>[]
+  | MessageActionRowOptions<ModalActionRowComponentResolvable>[];
   customId: string;
   title: string;
 }
@@ -7702,8 +7724,8 @@ export type Partialize<
   id: Snowflake;
   partial: true;
 } & {
-  [K in keyof Omit<T, 'client' | 'id' | 'partial' | E>]: K extends N ? null : K extends M ? T[K] | null : T[K];
-};
+    [K in keyof Omit<T, 'client' | 'id' | 'partial' | E>]: K extends N ? null : K extends M ? T[K] | null : T[K];
+  };
 
 export interface PartialDMChannel extends Partialize<DMChannel, null, null, 'lastMessageId'> {
   lastMessageId: undefined;
@@ -7941,8 +7963,8 @@ export interface SweeperDefinitions {
 
 export type SweeperOptions = {
   [K in keyof SweeperDefinitions]?: SweeperDefinitions[K][2] extends true
-    ? SweepOptions<SweeperDefinitions[K][0], SweeperDefinitions[K][1]> | LifetimeSweepOptions
-    : SweepOptions<SweeperDefinitions[K][0], SweeperDefinitions[K][1]>;
+  ? SweepOptions<SweeperDefinitions[K][0], SweeperDefinitions[K][1]> | LifetimeSweepOptions
+  : SweepOptions<SweeperDefinitions[K][0], SweeperDefinitions[K][1]>;
 };
 
 export interface LimitedCollectionOptions<K, V> {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6918,53 +6918,56 @@ export interface GuildWidgetSettingsData {
 
 export type GuildSearchMembersOptionsRangeValue = number | string;
 
-export type GuildSearchMembersOptionsRangeQuery<T extends GuildSearchMembersOptionsRangeValue = number> = {
+export interface GuildSearchMembersOptionsRangeQuery<
+  T extends GuildSearchMembersOptionsRangeValue = number,
+> {
   range: {
     gte?: T;
     lte?: T;
   };
-};
+}
 
-export type GuildSearchMembersOptionsOrQuery = {
+export interface GuildSearchMembersOptionsOrQuery {
   or_query: string[];
-};
+}
 
-export type GuildSearchMembersOptionsAndQuery = {
+export interface GuildSearchMembersOptionsAndQuery {
   and_query: string[];
-};
+}
 
 export type GuildSearchMembersOptionsListQuery =
   | GuildSearchMembersOptionsOrQuery
   | GuildSearchMembersOptionsAndQuery;
 
-export type GuildSearchMembersOptionsRangeable<T extends GuildSearchMembersOptionsRangeValue = number> =
-  | GuildSearchMembersOptionsRangeQuery<T>;
+export type GuildSearchMembersOptionsRangeable<
+  T extends GuildSearchMembersOptionsRangeValue = number,
+> = GuildSearchMembersOptionsRangeQuery<T>;
 
-export type GuildSearchMembersOptionsFlexibleQuery<T extends GuildSearchMembersOptionsRangeValue = number> =
-  | GuildSearchMembersOptionsListQuery
-  | GuildSearchMembersOptionsRangeable<T>;
+export type GuildSearchMembersOptionsFlexibleQuery<
+  T extends GuildSearchMembersOptionsRangeValue = number,
+> = GuildSearchMembersOptionsListQuery | GuildSearchMembersOptionsRangeable<T>;
 
-export type GuildSearchMembersOptionsSafetySignalsQuery = {
+export interface GuildSearchMembersOptionsSafetySignalsQuery {
   unusual_dm_activity_until?: GuildSearchMembersOptionsRangeQuery<number>;
   communication_disabled_until?: GuildSearchMembersOptionsRangeQuery<number>;
   unusual_account_activity?: boolean;
   automod_quarantined_username?: boolean;
-};
+}
 
-export type GuildSearchMembersOptionsFilterFields = {
+export interface GuildSearchMembersOptionsFilterFields {
   usernames?: GuildSearchMembersOptionsListQuery;
   role_ids?: GuildSearchMembersOptionsListQuery;
   guild_joined_at?: GuildSearchMembersOptionsRangeQuery<number>;
   user_id?: GuildSearchMembersOptionsRangeQuery<string>;
   source_invite_code?: GuildSearchMembersOptionsListQuery;
   safety_signals?: GuildSearchMembersOptionsSafetySignalsQuery;
-};
+}
 
-export type GuildSearchMembersOptions = {
+export interface GuildSearchMembersOptions {
   or_query?: GuildSearchMembersOptionsFilterFields;
   and_query?: GuildSearchMembersOptionsFilterFields;
   limit?: number;
-};
+}
 
 // TODO: use conditional types for better TS support
 export interface GuildScheduledEventCreateOptions {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -121,6 +121,7 @@ import {
   MessageReferenceTypes,
   SeparatorSpacingSizes,
   ApplicationType,
+  GuildMemberJoinSourceTypes
 } from './enums';
 import {
   APIApplicationRoleConnectionMetadata,
@@ -6916,9 +6917,9 @@ export interface GuildWidgetSettingsData {
   channel: GuildChannelResolvable | null;
 }
 
-export type GuildSearchMembersOptionsRangeValue = number | string;
+type GuildSearchMembersOptionsRangeValue = number | string;
 
-export interface GuildSearchMembersOptionsRangeQuery<
+interface GuildSearchMembersOptionsRangeQuery<
   T extends GuildSearchMembersOptionsRangeValue = number,
 > {
   range: {
@@ -6927,59 +6928,59 @@ export interface GuildSearchMembersOptionsRangeQuery<
   };
 }
 
-export interface GuildSearchMembersOptionsOrQuery {
+interface GuildSearchMembersOptionsOrQuery {
   or: string[];
 }
 
-export interface GuildSearchMembersOptionsAndQuery {
+interface GuildSearchMembersOptionsAndQuery {
   and: string[];
 }
 
-export type GuildSearchMembersOptionsListQuery =
+type GuildSearchMembersOptionsListQuery =
   | GuildSearchMembersOptionsOrQuery
   | GuildSearchMembersOptionsAndQuery;
 
-export interface GuildSearchMembersOptionsUsernamesQuery {
+interface GuildSearchMembersOptionsUsernamesQuery {
   or: string[];
 }
 
-export interface GuildSearchMembersOptionsUserQuery {
+interface GuildSearchMembersOptionsUserQuery {
   or: string[];
 }
 
-export interface GuildSearchMembersOptionsSourceInviteCodeQuery {
-  or: (GuildInviteSourceCode | string)[];
+interface GuildSearchMembersOptionsJoinSourceTypeQuery {
+  or: (GuildMemberJoinSourceTypes | string)[];
 }
 
-export type GuildSearchMembersOptionsRangeable<
+type GuildSearchMembersOptionsRangeable<
   T extends GuildSearchMembersOptionsRangeValue = number,
 > = GuildSearchMembersOptionsRangeQuery<T>;
 
-export type GuildSearchMembersOptionsFlexibleQuery<
+type GuildSearchMembersOptionsFlexibleQuery<
   T extends GuildSearchMembersOptionsRangeValue = number,
 > = GuildSearchMembersOptionsListQuery | GuildSearchMembersOptionsRangeable<T>;
 
-export interface GuildSearchMembersOptionsSafetySignalsOrOnlyQuery {
+interface GuildSearchMembersOptionsSafetySignalsOrOnlyQuery {
   or: (number | Date | boolean)[];
 }
 
-export interface GuildSearchMembersOptionsSafetySignalsQuery {
+interface GuildSearchMembersOptionsSafetySignalsQuery {
   unusualDmActivityUntil?: GuildSearchMembersOptionsRangeQuery<number | Date> | GuildSearchMembersOptionsSafetySignalsOrOnlyQuery;
   communicationDisabledUntil?: GuildSearchMembersOptionsRangeQuery<number | Date> | GuildSearchMembersOptionsSafetySignalsOrOnlyQuery;
   unusualAccountActivity?: boolean | GuildSearchMembersOptionsSafetySignalsOrOnlyQuery;
   automodQuarantinedUsername?: boolean | GuildSearchMembersOptionsSafetySignalsOrOnlyQuery;
 }
 
-export interface GuildSearchMembersOptionsFilterFields {
+interface GuildSearchMembersOptionsFilterFields {
   usernames?: GuildSearchMembersOptionsUsernamesQuery | string;
   roles?: GuildSearchMembersOptionsRoleQuery | RoleResolvable;
   guildJoinedAt?: GuildSearchMembersOptionsRangeQuery<number | Date>;
   users?: GuildSearchMembersOptionsUserQuery | string;
-  sourceInviteCode?: GuildSearchMembersOptionsSourceInviteCodeQuery | (number | string);
+  joinSourceType?: GuildSearchMembersOptionsJoinSourceTypeQuery | (number | string);
   safetySignals?: GuildSearchMembersOptionsSafetySignalsQuery;
 }
 
-export interface GuildSearchMembersOptionsRoleQuery {
+interface GuildSearchMembersOptionsRoleQuery {
   or?: RoleResolvable[];
   and?: RoleResolvable[];
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6916,11 +6916,55 @@ export interface GuildWidgetSettingsData {
   channel: GuildChannelResolvable | null;
 }
 
-export interface GuildSearchMembersOptions {
-  query: string;
+export type GuildSearchMembersOptionsRangeValue = number | string;
+
+export type GuildSearchMembersOptionsRangeQuery<T extends GuildSearchMembersOptionsRangeValue = number> = {
+  range: {
+    gte?: T;
+    lte?: T;
+  };
+};
+
+export type GuildSearchMembersOptionsOrQuery = {
+  or_query: string[];
+};
+
+export type GuildSearchMembersOptionsAndQuery = {
+  and_query: string[];
+};
+
+export type GuildSearchMembersOptionsListQuery =
+  | GuildSearchMembersOptionsOrQuery
+  | GuildSearchMembersOptionsAndQuery;
+
+export type GuildSearchMembersOptionsRangeable<T extends GuildSearchMembersOptionsRangeValue = number> =
+  | GuildSearchMembersOptionsRangeQuery<T>;
+
+export type GuildSearchMembersOptionsFlexibleQuery<T extends GuildSearchMembersOptionsRangeValue = number> =
+  | GuildSearchMembersOptionsListQuery
+  | GuildSearchMembersOptionsRangeable<T>;
+
+export type GuildSearchMembersOptionsSafetySignalsQuery = {
+  unusual_dm_activity_until?: GuildSearchMembersOptionsRangeQuery<number>;
+  communication_disabled_until?: GuildSearchMembersOptionsRangeQuery<number>;
+  unusual_account_activity?: boolean;
+  automod_quarantined_username?: boolean;
+};
+
+export type GuildSearchMembersOptionsFilterFields = {
+  usernames?: GuildSearchMembersOptionsListQuery;
+  role_ids?: GuildSearchMembersOptionsListQuery;
+  guild_joined_at?: GuildSearchMembersOptionsRangeQuery<number>;
+  user_id?: GuildSearchMembersOptionsRangeQuery<string>;
+  source_invite_code?: GuildSearchMembersOptionsListQuery;
+  safety_signals?: GuildSearchMembersOptionsSafetySignalsQuery;
+};
+
+export type GuildSearchMembersOptions = {
+  or_query?: GuildSearchMembersOptionsFilterFields;
+  and_query?: GuildSearchMembersOptionsFilterFields;
   limit?: number;
-  cache?: boolean;
-}
+};
 
 // TODO: use conditional types for better TS support
 export interface GuildScheduledEventCreateOptions {


### PR DESCRIPTION
This PR refactors the GuildMemberManager.search method to use Discord's new /members-search endpoint, replacing the older search logic. The updated system allows for advanced, flexible, and structured member querying, using logical and range-based filters.

Using new query system:
- "or" and "and" blocks
- Range filters (gte/lte) for dates
- Logical filters (or/and) for usernames, roles, and more
- Support for internal safety signal filters

Why?
- Greater flexibility
- Enables precise user searches for bots, tools, and dashboards