### PR TITLE
feat: Add support for fetching user profiles

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -148,6 +148,7 @@ exports.ThreadOnlyChannel = require('./structures/ThreadOnlyChannel');
 exports.ThreadMember = require('./structures/ThreadMember');
 exports.Typing = require('./structures/Typing');
 exports.User = require('./structures/User');
+exports.UserProfile = require('./structures/UserProfile');
 exports.VoiceChannel = require('./structures/VoiceChannel');
 exports.VoiceChannelEffect = require('./structures/VoiceChannelEffect');
 exports.VoiceRegion = require('./structures/VoiceRegion');

--- a/src/managers/UserManager.js
+++ b/src/managers/UserManager.js
@@ -6,6 +6,7 @@ const { GuildMember } = require('../structures/GuildMember');
 const { Message } = require('../structures/Message');
 const ThreadMember = require('../structures/ThreadMember');
 const User = require('../structures/User');
+const UserProfile = require('../structures/UserProfile');
 
 /**
  * Manages API methods for users and stores their cache.
@@ -97,6 +98,32 @@ class UserManager extends CachedManager {
 
     const data = await this.client.api.users(id).get();
     return this._add(data, cache);
+  }
+
+  /**
+   * Fetches a user's profile.
+   * @param {UserResolvable} user The user to fetch the profile of
+   * @param {Object} [options] Options for fetching the profile
+   * @param {boolean} [options.withMutualGuilds=true] Whether to fetch mutual guilds
+   * @param {boolean} [options.withMutualFriends=true] Whether to fetch mutual friends
+   * @param {boolean} [options.withMutualFriendsCount=false] Whether to fetch the mutual friends count
+   * @param {string} [options.type='popout'] The type of profile to fetch
+   * @returns {Promise<UserProfile>}
+   */
+  async fetchProfile(
+    user,
+    { withMutualGuilds = true, withMutualFriends = true, withMutualFriendsCount = false, type = 'popout' } = {},
+  ) {
+    const id = this.resolveId(user);
+    const data = await this.client.api.users(id).profile.get({
+      query: {
+        with_mutual_guilds: withMutualGuilds,
+        with_mutual_friends: withMutualFriends,
+        with_mutual_friends_count: withMutualFriendsCount,
+        type,
+      },
+    });
+    return new UserProfile(this.client, data);
   }
 
   /**

--- a/src/structures/User.js
+++ b/src/structures/User.js
@@ -405,26 +405,16 @@ class User extends Base {
   }
 
   /**
-   * Returns a user profile object for a given user ID.
-   * <info>This endpoint requires one of the following:
-   * - The user is a bot
-   * - The user shares a mutual guild with the current user
-   * - The user is a friend of the current user
-   * - The user is a friend suggestion of the current user
-   * - The user has an outgoing friend request to the current user</info>
-   * @param {Snowflake} [guildId] The guild ID to get the user's member profile in
-   * @returns {Promise<Object>}
-   * @see {@link https://discord-userdoccers.vercel.app/resources/user#response-body}
+   * Fetches the user's profile.
+   * @param {Object} [options] Options for fetching the profile
+   * @param {boolean} [options.withMutualGuilds=true] Whether to fetch mutual guilds
+   * @param {boolean} [options.withMutualFriends=true] Whether to fetch mutual friends
+   * @param {boolean} [options.withMutualFriendsCount=false] Whether to fetch the mutual friends count
+   * @param {string} [options.type='popout'] The type of profile to fetch
+   * @returns {Promise<UserProfile>}
    */
-  getProfile(guildId) {
-    return this.client.api.users(this.id).profile.get({
-      query: {
-        with_mutual_guilds: true,
-        with_mutual_friends: true,
-        with_mutual_friends_count: true,
-        guild_id: guildId,
-      },
-    });
+  fetchProfile(options) {
+    return this.client.users.fetchProfile(this.id, options);
   }
 
   /**

--- a/src/structures/UserProfile.js
+++ b/src/structures/UserProfile.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const Base = require('./Base');
+
+/**
+ * Represents a user's profile.
+ * @extends {Base}
+ */
+class UserProfile extends Base {
+  constructor(client, data) {
+    super(client);
+    this._patch(data);
+  }
+
+  _patch(data) {
+    /**
+     * The user object
+     * @type {User}
+     */
+    if ('user' in data) {
+      this.user = this.client.users.cache.get(data.user.id) ?? this.client.users._add(data.user);
+    }
+
+    /**
+     * The user's connected accounts
+     * @type {Object[]}
+     */
+    if ('connected_accounts' in data) {
+      this.connectedAccounts = data.connected_accounts;
+    } else {
+      this.connectedAccounts ??= [];
+    }
+
+    /**
+     * The type of Nitro subscription on a user's account
+     * @type {?PremiumType}
+     */
+    if ('premium_type' in data) {
+      this.premiumType = data.premium_type;
+    } else {
+      this.premiumType ??= null;
+    }
+
+    if ('premium_since' in data) {
+      /**
+       * The time the user subscribed to Nitro
+       * @type {?Date}
+       */
+      this.premiumSince = data.premium_since ? new Date(data.premium_since) : null;
+    } else {
+      this.premiumSince ??= null;
+    }
+
+    if ('premium_guild_since' in data) {
+      /**
+       * The time the user first boosted a guild
+       * @type {?Date}
+       */
+      this.premiumGuildSince = data.premium_guild_since ? new Date(data.premium_guild_since) : null;
+    } else {
+      this.premiumGuildSince ??= null;
+    }
+
+    if ('user_profile' in data) {
+      /**
+       * The user's bio
+       * @type {?string}
+       */
+      this.bio = data.user_profile.bio;
+      /**
+       * The user's accent color
+       * @type {?number}
+       */
+      this.accentColor = data.user_profile.accent_color;
+      /**
+       * The user's pronouns
+       * @type {?string}
+       */
+      this.pronouns = data.user_profile.pronouns;
+    } else {
+      this.bio ??= null;
+      this.accentColor ??= null;
+      this.pronouns ??= null;
+    }
+
+    /**
+     * The user's badges
+     * @type {Object[]}
+     */
+    if ('badges' in data) {
+      this.badges = data.badges;
+    } else {
+      this.badges ??= [];
+    }
+
+    /**
+     * The user's guild-specific badges
+     * @type {Object[]}
+     */
+    if ('guild_badges' in data) {
+      this.guildBadges = data.guild_badges;
+    } else {
+      this.guildBadges ??= [];
+    }
+
+    /**
+     * The mutual guilds between the client and the user
+     * @type {Object[]}
+     */
+    if ('mutual_guilds' in data) {
+      this.mutualGuilds = data.mutual_guilds;
+    } else {
+      this.mutualGuilds ??= [];
+    }
+
+    /**
+     * The mutual friends between the client and the user
+     * @type {User[]}
+     */
+    if ('mutual_friends' in data) {
+      this.mutualFriends = data.mutual_friends.map(f => this.client.users.cache.get(f.id) ?? this.client.users._add(f));
+    } else {
+      this.mutualFriends ??= [];
+    }
+  }
+
+  /**
+   * The timestamp the user subscribed to Nitro
+   * @type {?number}
+   * @readonly
+   */
+  get premiumSinceTimestamp() {
+    return this.premiumSince?.getTime() ?? null;
+  }
+
+  /**
+   * The timestamp the user first boosted a guild
+   * @type {?number}
+   * @readonly
+   */
+  get premiumGuildSinceTimestamp() {
+    return this.premiumGuildSince?.getTime() ?? null;
+  }
+
+  /**
+   * The timestamp the user was created at
+   * @type {number}
+   * @readonly
+   */
+  get createdTimestamp() {
+    return this.user.createdTimestamp;
+  }
+
+  /**
+   * The time the user was created at
+   * @type {Date}
+   * @readonly
+   */
+  get createdAt() {
+    return this.user.createdAt;
+  }
+
+  /**
+   * When concatenated with a string, this automatically returns the user's mention instead of the UserProfile object.
+   * @returns {string}
+   */
+  toString() {
+    return this.user.toString();
+  }
+}
+
+module.exports = UserProfile;


### PR DESCRIPTION
This commit introduces the ability to fetch detailed user profiles from the Discord API.

- A new `UserProfile` structure has been added to represent the profile data, including connected accounts, mutual guilds/friends, and bio.
- A `fetchProfile` method has been added to `UserManager` to perform the API request. This method allows for customization of the query parameters.
- The `User` structure now has a `fetchProfile` method, which is a convenient shortcut to `UserManager#fetchProfile`.
- The `UserProfile` structure is exported from the main entry point of the library.